### PR TITLE
Feat: Only 1 registration at a time and More feedback to user

### DIFF
--- a/app/src/main/java/com/example/myapplication/RegisterFragment.kt
+++ b/app/src/main/java/com/example/myapplication/RegisterFragment.kt
@@ -1,14 +1,11 @@
 package com.example.myapplication
 
-import android.app.Activity
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.IntentSenderRequest
-import androidx.activity.result.contract.ActivityResultContracts
+import android.widget.Toast
 import androidx.lifecycle.lifecycleScope
 import com.example.myapplication.databinding.FragmentRegisterBinding
 import com.example.myapplication.services.yourbackend.YourBackendHttpClientFactory
@@ -24,7 +21,6 @@ class RegisterFragment : Fragment() {
     private var _binding: FragmentRegisterBinding? = null
 
     private lateinit var _passwordless: PasswordlessClient
-    private lateinit var _registrationIntentLauncher: ActivityResultLauncher<IntentSenderRequest>
 
     // This property is only valid between onCreateView and
     // onDestroyView.
@@ -44,19 +40,12 @@ class RegisterFragment : Fragment() {
             DemoPasswordlessOptions.ORIGIN,
             DemoPasswordlessOptions.API_URL)
 
-        _passwordless = PasswordlessClient(fido2ApiClient, options,this.activity)
-
-        _registrationIntentLauncher = registerForActivityResult(
-            ActivityResultContracts.StartIntentSenderForResult()
-        ) { result ->
-            // This callback is invoked when the activity is finished
-            if (result.resultCode == Activity.RESULT_OK) {
-                // Call the suspend function in a coroutine
-                lifecycleScope.launch {
-                    _passwordless::handleRegistration
-                }
+        _passwordless = PasswordlessClient(fido2ApiClient, options,this.requireActivity(),lifecycleScope) { success, result ->
+            // If the registration is successful, then we will get the final result here
+            if (success) {
+                Toast.makeText(context, "Registration successful: $result", Toast.LENGTH_SHORT).show()
             } else {
-                // Handle the result accordingly if needed
+                Toast.makeText(context, "Registration failed: $result", Toast.LENGTH_SHORT).show()
             }
         }
 
@@ -67,18 +56,35 @@ class RegisterFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         binding.buttonRegister.setOnClickListener {
+            if(_passwordless.isRegistrationInProgress){
+                Toast.makeText(context, "Please wait!!", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
             lifecycleScope.launch {
                 val httpClient = YourBackendHttpClientFactory.create(DemoPasswordlessOptions.YOUR_BACKEND_URL)
                 val alias = binding.aliasEditText.text.toString()
                 val username = binding.usernameEditText.text.toString()
-                val responseToken = httpClient.register(UserRegisterRequest(username,alias)).body()?.token!!
-                _passwordless.register(responseToken,alias+username)
+                try {
+                    val responseToken = httpClient.register(UserRegisterRequest(username,alias)).body()?.token!!
+                    _passwordless.register(responseToken,alias+username) { success , exception ->
+                        // This is called when we got the response for register/begin and fido2 intent has started
+                        // Note: We do not get the final result here.
+                        if (success) {
+                            Toast.makeText(context,"Registration started", Toast.LENGTH_SHORT).show()
+                        } else {
+                            Toast.makeText(context, "Exception: "+exception?.message.toString(), Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }catch (e: Exception){
+                    Toast.makeText(context, e.message.toString(), Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        _passwordless.cancel()
         _binding = null
     }
 }

--- a/passwordless/src/main/java/dev/passwordless/android/PasswordlessClient.kt
+++ b/passwordless/src/main/java/dev/passwordless/android/PasswordlessClient.kt
@@ -1,12 +1,11 @@
 package dev.passwordless.android
 
 import android.app.Activity
-import android.app.PendingIntent
 import android.util.Log
+import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.fido.Fido
 import com.google.android.gms.fido.fido2.Fido2ApiClient
 import com.google.android.gms.fido.fido2.api.common.AuthenticatorErrorResponse
@@ -25,103 +24,206 @@ import dev.passwordless.android.rest.converters.PublicKeyCredentialConverter
 import dev.passwordless.android.rest.exceptions.PasswordlessApiException
 import dev.passwordless.android.rest.exceptions.PasswordlessCredentialCreateException
 import dev.passwordless.android.rest.exceptions.ProblemDetails
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 
+/**
+ * Manages the communication with the Fido2 API and performs registration operations for the Passwordless authentication flow.
+ *
+ * @param fido2ApiClient The Fido2ApiClient instance for interacting with the Fido2 API.
+ * @param options The configuration options for Passwordless authentication.
+ * @param activity The ComponentActivity associated with the PasswordlessClient for launching the registration intent.
+ * @param externalScope The CoroutineScope for launching coroutines related to Passwordless operations (optional).
+ * If this scope is not provided, then call the cancel function in onDestroy method.
+ * @param onHandleRegistrationResult Callback function to handle the result of the registration process.
+ */
 class PasswordlessClient(
-    fido2ApiClient: Fido2ApiClient?,
+    fido2ApiClient: Fido2ApiClient,
     options: PasswordlessOptions,
-    activity: FragmentActivity?
+    activity: ComponentActivity,
+    externalScope: CoroutineScope? = null,
+    private val onHandleRegistrationResult: (Boolean, Any?) -> Unit
 ) {
-    private val _fido2ApiClient: Fido2ApiClient? = fido2ApiClient
+    private val _fido2ApiClient: Fido2ApiClient = fido2ApiClient
     private val _httpClient: PasswordlessHttpClient
     private val _options: PasswordlessOptions = options
+    private val _externalScope = externalScope ?: CoroutineScope(Dispatchers.Main)
 
-    // request scoped start
-    private var _nickname: String? = null
-    // request scoped end
-    private val createCredentialIntentLauncher = activity?.registerForActivityResult(
+
+    private val _createCredentialIntentLauncher = activity.registerForActivityResult(
         ActivityResultContracts.StartIntentSenderForResult(),
         ::handleRegistration
     )
-    private var sessionId:String?=null
+
+    /**
+     * Stores data related to the current registration request, specifically the session ID and nickname.
+     */
+    private var _currentRequestData: Pair<String, String>? = null
+
+    /**
+     * A flag used to ensure only one registration request is processed at a time until completion.
+     * When set to `true`, it indicates that a registration request is already in progress.
+     * When set to `false`, a new registration request can be initiated.
+     */
+    private var _lock = false
+
+    /**
+     * Provides the status of any ongoing registration request.
+     *
+     * - `true`: Indicates that a previous registration request is already in progress.
+     *    A new request should wait until the ongoing one completes or fails.
+     *
+     * - `false`: Indicates that no registration request is currently in progress.
+     *    A new registration request can be initiated.
+     */
+    val isRegistrationInProgress
+        get() = _lock
+
+
     init {
         _httpClient = PasswordlessHttpClientFactory.create(options)
     }
 
     /**
-     * @param token The registration token obtained from your backend
-     * @param nickname The nickname for the credential
-     * @return
+     * Initiates the registration process for Passwordless authentication.
+     *
+     * @param token The registration token obtained from the backend.
+     * @param nickname The nickname for the credential.
+     * @param onRegisterResult Callback function to handle the registration result.
      */
-    suspend fun register(token: String, nickname: String? = null): PendingIntent? {
-        _nickname = nickname
-
-        val beginInputModel = RegisterBeginRequest(
-            token = token,
-            rpId = _options.rpId,
-            origin = _options.origin
-        )
-
-        _fido2ApiClient?.let { client ->
+    fun register(
+        token: String,
+        nickname: String = "",
+        onRegisterResult: (Boolean, Exception?) -> Unit
+    ) = _externalScope.launch {
+        synchronized(this) {
+            if (_lock) {
+                onRegisterResult(false, Exception("One request already in progress"))
+                return@launch
+            }
+            _lock = true
+        }
+        withContext(Dispatchers.IO) {
             try {
+                val beginInputModel = RegisterBeginRequest(
+                    token = token,
+                    rpId = _options.rpId,
+                    origin = _options.origin
+                )
+
                 val beginResponse = _httpClient.registerBegin(beginInputModel)
+
                 if (!beginResponse.isSuccessful) {
-                    val problemDetails = ProblemDetails("", beginResponse.message(), beginResponse.code(), "")
+                    val problemDetails =
+                        ProblemDetails("", beginResponse.message(), beginResponse.code(), "")
                     throw PasswordlessApiException(problemDetails)
                 }
+
                 val beginResult: RegisterBeginResponse = beginResponse.body()!!
-                sessionId = beginResult.session
+                _currentRequestData = Pair(beginResult.session, nickname)
 
+                val credentialCreationOptions = publicKeyCredentialCreationOptions(beginResult)
 
-                val credentialCreationOptions = PublicKeyCredentialCreationOptions
-                    .Builder()
-                    .setChallenge(beginResult.data.challenge)
-                    .setTimeoutSeconds(beginResult.data.timeout.toDouble())
-                    .setRp(PublicKeyCredentialRpEntity(beginResult.data.rp.id,beginResult.data.rp.name,null))
-                    .setUser(PublicKeyCredentialUserEntity(beginResult.data.user.id,beginResult.data.user.name,"",beginResult.data.user.displayName))
-                    .setParameters(beginResult.data.getPublicKeyCredentialParameters())
-                    .build()
+                val createdCredential =
+                    _fido2ApiClient.getRegisterPendingIntent(credentialCreationOptions)
+                        .await()
+                        ?: throw Exception("Creation intent is null")
 
-                val creationIntent = client.getRegisterPendingIntent(credentialCreationOptions)
-
-                val createdCredential = creationIntent.await()
-                createCredentialIntentLauncher!!.launch(
-                    IntentSenderRequest.Builder(createdCredential).build()
+                _createCredentialIntentLauncher.launch(
+                    IntentSenderRequest.Builder(
+                        createdCredential
+                    ).build()
                 )
+
+                withContext(Dispatchers.Main) {
+                    onRegisterResult(true, null)
+                }
             } catch (e: Exception) {
                 Log.e("passwordless-register-begin", "Cannot call registerRequest", e)
-            }
-        }
-        return null
-    }
-
-    /**
-     * @param activityResult
-     */
-    fun handleRegistration(activityResult: ActivityResult) {
-        val bytes = activityResult.data?.getByteArrayExtra(Fido.FIDO2_KEY_CREDENTIAL_EXTRA)
-        when {
-            (activityResult.resultCode != Activity.RESULT_OK || bytes == null) ->
-                throw PasswordlessCredentialCreateException("Failed to create credential.")
-            else -> {
-                val credential = PublicKeyCredential.deserializeFromBytes(bytes)
-                if (credential.response is AuthenticatorErrorResponse) {
-                    val errorResponse = credential.response as AuthenticatorErrorResponse
-                    throw PasswordlessCredentialCreateException(errorResponse.errorMessage)
-                } else {
-                    val request = RegisterCompleteRequest(
-                        session = sessionId!!,
-                        response = PublicKeyCredentialConverter.convertJson(credential.toJson()),
-                        nickname = _nickname,
-                        origin = _options.origin,
-                        rpId = _options.rpId
-                    )
-                    // todo: need to remove runBlocking
-                    runBlocking {  _httpClient.registerComplete(request)}
-
+                synchronized(this) {
+                    _currentRequestData = null
+                    _lock = false
+                }
+                withContext(Dispatchers.Main) {
+                    onRegisterResult(false, e)
                 }
             }
         }
+    }
+
+    private fun publicKeyCredentialCreationOptions(beginResult: RegisterBeginResponse): PublicKeyCredentialCreationOptions =
+        beginResult.data.run {
+            PublicKeyCredentialCreationOptions
+                .Builder()
+                .setChallenge(challenge)
+                .setTimeoutSeconds(timeout.toDouble())
+                .setRp(PublicKeyCredentialRpEntity(rp.id, rp.name, null))
+                .setUser(PublicKeyCredentialUserEntity(user.id, user.name, "", user.displayName))
+                .setParameters(getPublicKeyCredentialParameters())
+                .build()
+        }
+
+
+    /**
+     * Handles the result of the registration process when the credential creation intent returns.
+     *
+     * @param activityResult The result of the registration intent.
+     */
+    private fun handleRegistration(activityResult: ActivityResult) =
+        _externalScope.launch(Dispatchers.IO) {
+            try {
+                val bytes = activityResult.data?.getByteArrayExtra(Fido.FIDO2_KEY_CREDENTIAL_EXTRA)
+                val sessionId = _currentRequestData!!.first
+                val nickname = _currentRequestData!!.second
+                when {
+                    (activityResult.resultCode != Activity.RESULT_OK || bytes == null) ->
+                        throw PasswordlessCredentialCreateException("Failed to create credential.")
+
+                    else -> {
+                        val credential = PublicKeyCredential.deserializeFromBytes(bytes)
+                        if (credential.response is AuthenticatorErrorResponse) {
+                            val errorResponse = credential.response as AuthenticatorErrorResponse
+                            throw PasswordlessCredentialCreateException(errorResponse.errorMessage)
+                        } else {
+                            val request = RegisterCompleteRequest(
+                                session = sessionId,
+                                response = PublicKeyCredentialConverter.convertJson(credential.toJson()),
+                                nickname = nickname,
+                                origin = _options.origin,
+                                rpId = _options.rpId
+                            )
+                            val response = _httpClient.registerComplete(request)
+                            if (response.isSuccessful) {
+                                withContext(Dispatchers.Main) {
+                                    onHandleRegistrationResult(true, response.body())
+                                }
+                            } else {
+                                throw PasswordlessCredentialCreateException("Network call failed")
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    onHandleRegistrationResult(false, e)
+                }
+            } finally {
+                synchronized(this) {
+                    _currentRequestData = null
+                    _lock = false
+                }
+            }
+        }
+
+    /**
+     * Cancel all ongoing coroutines in the scope.
+     * If no scope is provided then this should be called in onDestroy
+     */
+    fun cancel() {
+        _externalScope.cancel()
     }
 }


### PR DESCRIPTION
## 🚧 Type of change


- 🚀 New feature development
- 🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)


## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
1. There should be only one registration, which should take place at a time.
2. The user should get feedback on what's happening in the SDK.
3. Fixed use of coroutines 

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

- **RegisterFragment.kt:** : Updated the way to use SDK. There are 2 places where the callback function provided by PasswordlessClient to handle the result of the registration process, displaying appropriate toasts for success or failure.
Added a check (_passwordless.isRegistrationInProgress) to ensure that only one registration takes place at a time

- **PasswordlessClient.kt:** 
1. Used coroutines for calling the backend API
2. Handled the _lock, which locks the registration process until completion or some exception happens
3. Added lambda functions that notify the user about current status of registration on both registration start and registration complete.
4. Updated documentation

### Testing
Passed: Manual testing of trying multiple registrations and feedback on registration start and registration complete.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
