### PR TITLE
Split `AddCredentialsFragment`

### DIFF
--- a/app/src/main/java/dev/passwordless/sampleapp/AddCredentialFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/AddCredentialFragment.kt
@@ -1,4 +1,4 @@
-package dev.passwordless.sampleapp
+package dev.passwordless.sampleapp;
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -8,45 +8,39 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import dev.passwordless.sampleapp.databinding.FragmentRegisterBinding
 import dagger.hilt.android.AndroidEntryPoint
 import dev.passwordless.android.PasswordlessClient
-import dev.passwordless.android.utils.PasswordlessUtils.Companion.getPasskeyFailureMessage
+import dev.passwordless.android.utils.PasswordlessUtils
+import dev.passwordless.sampleapp.auth.Session
 import dev.passwordless.sampleapp.contracts.UserRegisterRequest
+import dev.passwordless.sampleapp.databinding.FragmentAddCredentialBinding
 import dev.passwordless.sampleapp.yourbackend.YourBackendHttpClient
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class RegisterFragment : Fragment() {
-
-    private var _binding: FragmentRegisterBinding? = null
-
-    @Inject
-    lateinit var _passwordless: PasswordlessClient
-
+class AddCredentialFragment : Fragment() {
     @Inject
     lateinit var httpClient: YourBackendHttpClient
+    @Inject
+    lateinit var session: Session
+    @Inject
+    lateinit var passwordless: PasswordlessClient
 
-    // This property is only valid between onCreateView and
-    // onDestroyView.
+    private var _binding: FragmentAddCredentialBinding? = null
     private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        _binding = FragmentAddCredentialBinding.inflate(inflater, container, false)
 
-        _binding = FragmentRegisterBinding.inflate(inflater, container, false)
-
-        handleLoginNavigation()
-        return binding.root
-    }
-
-    private fun handleLoginNavigation() {
-        binding.loginTV.setOnClickListener {
-            findNavController().navigate(R.id.action_registration_to_login_fragment)
+        if (!session.isLoggedIn()) {
+            findNavController().navigate(R.id.action_add_credential_to_login_fragment)
         }
+
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -55,26 +49,26 @@ class RegisterFragment : Fragment() {
         binding.buttonRegister.setOnClickListener {
             lifecycleScope.launch {
                 val alias = binding.aliasEditText.text.toString()
-                val username = binding.usernameEditText.text.toString()
+                val username = session.getUsername()!!
                 try {
-                    val responseToken =
+                    val response =
                         httpClient.register(UserRegisterRequest(username, alias)).body()?.token!!
-                    _passwordless.register(
-                        responseToken,
+                    passwordless.register(
+                        response,
                         alias + username
                     ) { success, exception, result ->
                         if (success) {
-                            Toast.makeText(context, result.toString(), Toast.LENGTH_SHORT).show()
+                            findNavController().navigate(R.id.action_add_credential_to_credentials_fragment)
                         } else {
                             Toast.makeText(
                                 context,
-                                "Exception: " + getPasskeyFailureMessage(exception as Exception),
+                                "Exception: " + PasswordlessUtils.getPasskeyFailureMessage(exception as Exception),
                                 Toast.LENGTH_SHORT
                             ).show()
                         }
                     }
                 } catch (e: Exception) {
-                    Toast.makeText(context, e.message.toString(), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, e.message.toString(), Toast.LENGTH_LONG).show()
                 }
             }
         }

--- a/app/src/main/java/dev/passwordless/sampleapp/CredentialsFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/CredentialsFragment.kt
@@ -11,9 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import dev.passwordless.android.PasswordlessClient
-import dev.passwordless.android.utils.PasswordlessUtils
 import dev.passwordless.sampleapp.auth.Session
-import dev.passwordless.sampleapp.contracts.UserRegisterRequest
 import dev.passwordless.sampleapp.databinding.FragmentCredentialsBinding
 import dev.passwordless.sampleapp.yourbackend.YourBackendHttpClient
 import kotlinx.coroutines.Dispatchers
@@ -29,8 +27,6 @@ class CredentialsFragment : Fragment() {
 
     private var _binding: FragmentCredentialsBinding? = null
     private val binding get() = _binding!!
-    lateinit var listView: ListView
-
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -51,7 +47,7 @@ class CredentialsFragment : Fragment() {
         }
 
         if (!session.isLoggedIn()) {
-            findNavController().navigate(R.id.action_to_login_fragment)
+            findNavController().navigate(R.id.action_credentials_to_login_fragment)
         }
 
         return binding.root
@@ -60,30 +56,8 @@ class CredentialsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.buttonRegister.setOnClickListener {
-            lifecycleScope.launch {
-                val alias = binding.aliasEditText.text.toString()
-                val username = session.getUsername()!!
-                try {
-                    val response = httpClient.register(UserRegisterRequest(username, alias)).body()?.token!!
-                    passwordless.register(
-                        response,
-                        alias + username
-                    ) { success, exception, result ->
-                        if (success) {
-                            findNavController().navigate(R.id.credentials_fragment)
-                        } else {
-                            Toast.makeText(
-                                context,
-                                "Exception: " + PasswordlessUtils.getPasskeyFailureMessage(exception as Exception),
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        }
-                    }
-                } catch (e: Exception) {
-                    Toast.makeText(context, e.message.toString(), Toast.LENGTH_LONG).show()
-                }
-            }
+        binding.addCredentialButton.setOnClickListener {
+            findNavController().navigate(R.id.action_credentials_to_add_credential_fragment)
         }
     }
 

--- a/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
@@ -109,7 +109,7 @@ class LoginFragment : Fragment() {
             }
         }
         binding.registerNavTV.setOnClickListener {
-            findNavController().navigate(R.id.action_to_registration_fragment)
+            findNavController().navigate(R.id.action_login_to_registration_fragment)
         }
     }
 

--- a/app/src/main/res/layout/fragment_add_credential.xml
+++ b/app/src/main/res/layout/fragment_add_credential.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="dev.passwordless.sampleapp.AddCredentialFragment">
+
+    <LinearLayout
+        android:gravity="center"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:orientation="vertical"
+        android:showDividers="middle"
+        android:divider="@drawable/empty_tall_divider">
+
+        <EditText
+            android:gravity="center"
+            android:id="@+id/aliasEditText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:hint="@string/alias_hint"
+            android:inputType="text" />
+
+        <TextView
+            android:gravity="center"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/alias_hint_description" />
+
+        <Button
+            android:id="@+id/buttonRegister"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/add_credential" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/fragment_credentials.xml
+++ b/app/src/main/res/layout/fragment_credentials.xml
@@ -1,50 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:padding="16dp"
     tools:context="dev.passwordless.sampleapp.CredentialsFragment">
 
-    <LinearLayout
-        android:gravity="center"
+    <ListView
+        android:id="@+id/credentials_list"
+        android:layout_marginTop="16dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:orientation="vertical"
-        android:showDividers="middle"
-        android:divider="@drawable/empty_tall_divider">
+        android:divider="@android:drawable/divider_horizontal_dark">
 
-        <EditText
-            android:gravity="center"
-            android:id="@+id/aliasEditText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:hint="@string/alias_hint"
-            android:inputType="text" />
+    </ListView>
 
-        <TextView
-            android:gravity="center"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/alias_hint_description" />
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/add_credential_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginEnd="@dimen/fab_margin"
+        android:layout_marginBottom="16dp"
+        android:tint="@color/white"
+        app:srcCompat="@android:drawable/ic_input_add" />
 
-        <Button
-            android:id="@+id/buttonRegister"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/add_credential" />
-
-        <ListView
-            android:id="@+id/credentials_list"
-            android:layout_marginTop="16dp"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:divider="@android:drawable/divider_horizontal_dark">
-
-        </ListView>
-
-    </LinearLayout>
-
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -12,7 +12,7 @@
         tools:layout="@layout/fragment_register">
 
         <action
-            android:id="@+id/action_to_login_fragment"
+            android:id="@+id/action_registration_to_login_fragment"
             app:destination="@id/login_fragment" />
     </fragment>
     <fragment
@@ -22,7 +22,7 @@
         tools:layout="@layout/fragment_login">
 
         <action
-            android:id="@+id/action_to_registration_fragment"
+            android:id="@+id/action_login_to_registration_fragment"
             app:destination="@id/registration_fragment" />
 
         <action
@@ -36,7 +36,24 @@
         tools:layout="@layout/fragment_credentials">
 
         <action
-            android:id="@+id/action_to_login_fragment"
+            android:id="@+id/action_credentials_to_login_fragment"
+            app:destination="@id/login_fragment" />
+
+        <action
+            android:id="@+id/action_credentials_to_add_credential_fragment"
+            app:destination="@id/add_credential_fragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/add_credential_fragment"
+        android:name="dev.passwordless.sampleapp.AddCredentialFragment"
+        android:label="@string/add_credential_fragment_label"
+        tools:layout="@layout/fragment_add_credential">
+
+        <action
+            android:id="@+id/action_add_credential_to_credentials_fragment"
+            app:destination="@id/credentials_fragment" />
+        <action
+            android:id="@+id/action_add_credential_to_login_fragment"
             app:destination="@id/login_fragment" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="register_fragment_label">Registration</string>
     <string name="login_fragment_label">Login</string>
     <string name="credentials_fragment_label">Credentials</string>
+    <string name="add_credential_fragment_label">Add Credential</string>
+
     <string name="register">Register</string>
     <string name="previous">Previous</string>
 


### PR DESCRIPTION
## 🎟️ Tracking


## 🚧 Type of change

- 🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)

## 📔 Objective

Splitting the `AddCredentialsFragment`, so the list of credentials looks cleaner.

## 📋 Code changes

n/a

## 📸 Screenshots

<img width="306" alt="image" src="https://github.com/bitwarden/passwordless-android/assets/1045327/55b4d57e-6fd4-4c9c-9782-5f1f3ae97b9d">

<img width="306" alt="image" src="https://github.com/bitwarden/passwordless-android/assets/1045327/14665c7d-ac59-4386-becb-59b5533b2325">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
