### PR TITLE
Fix `SharedPreferences` not reading JWT correctly.

### DIFF
--- a/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
@@ -1,12 +1,14 @@
 package dev.passwordless.sampleapp
 
-import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -17,7 +19,6 @@ import dev.passwordless.android.PasswordlessClient
 import dev.passwordless.sampleapp.contracts.UserLoginRequest
 import dev.passwordless.sampleapp.databinding.FragmentLoginBinding
 import dev.passwordless.sampleapp.yourbackend.YourBackendHttpClient
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -54,6 +55,15 @@ class LoginFragment : Fragment() {
     ): View {
 
         _binding = FragmentLoginBinding.inflate(inflater, container, false)
+
+        val callback: OnBackPressedCallback =
+            object : OnBackPressedCallback(true /* enabled by default */) {
+                override fun handleOnBackPressed() {
+                    Log.d("BACKBUTTON", "Back button clicks")
+                }
+            }
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, callback)
 
         return binding.root
 

--- a/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
@@ -1,5 +1,6 @@
 package dev.passwordless.sampleapp
 
+import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
@@ -16,6 +17,7 @@ import androidx.preference.PreferenceManager
 import com.auth0.android.jwt.JWT
 import dagger.hilt.android.AndroidEntryPoint
 import dev.passwordless.android.PasswordlessClient
+import dev.passwordless.sampleapp.auth.Session
 import dev.passwordless.sampleapp.contracts.UserLoginRequest
 import dev.passwordless.sampleapp.databinding.FragmentLoginBinding
 import dev.passwordless.sampleapp.yourbackend.YourBackendHttpClient
@@ -31,22 +33,12 @@ class LoginFragment : Fragment() {
 
     private var _binding: FragmentLoginBinding? = null
 
-    @Inject
-    lateinit var _passwordless: PasswordlessClient
+    @Inject lateinit var _passwordless: PasswordlessClient
 
-    @Inject
-    lateinit var httpClient: YourBackendHttpClient
+    @Inject lateinit var httpClient: YourBackendHttpClient
 
-    private val mPreferenceListener: SharedPreferences.OnSharedPreferenceChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
-        if (key == "jwt") {
-            if (sharedPreferences.getString("jwt", null) != null) {
-                findNavController().navigate(R.id.action_login_to_credentials_fragment)
-            }
-        }
-    }
+    @Inject lateinit var session: Session
 
-    // This property is only valid between onCreateView and
-    // onDestroyView.
     private val binding get() = _binding!!
 
     override fun onCreateView(
@@ -91,17 +83,8 @@ class LoginFragment : Fragment() {
                                         Toast.LENGTH_SHORT
                                     ).show()
                                 } else {
-                                    val sharedPreferences =
-                                        PreferenceManager.getDefaultSharedPreferences(
-                                            requireActivity()!!.applicationContext
-                                        )
-
-                                    sharedPreferences.registerOnSharedPreferenceChangeListener(mPreferenceListener)
-
-                                    val editor = sharedPreferences.edit()
-                                    editor.putString("jwt", data.jwtToken)
-                                    editor.putString("userId", jwt.getClaim("nameid").asString())
-                                    editor.commit()
+                                    session.setJwtString(data.jwtToken)
+                                    findNavController().navigate(R.id.action_login_to_credentials_fragment)
                                 }
                             }
                         }
@@ -125,8 +108,6 @@ class LoginFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        PreferenceManager.getDefaultSharedPreferences(requireActivity().applicationContext)
-            .unregisterOnSharedPreferenceChangeListener(mPreferenceListener)
         _binding = null
     }
 }

--- a/app/src/main/java/dev/passwordless/sampleapp/MainActivity.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/MainActivity.kt
@@ -1,12 +1,10 @@
 package dev.passwordless.sampleapp
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
@@ -14,13 +12,13 @@ import androidx.preference.PreferenceManager
 import dagger.hilt.android.AndroidEntryPoint
 import dev.passwordless.sampleapp.databinding.ActivityMainBinding
 
-
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     private lateinit var appBarConfiguration: AppBarConfiguration
     private lateinit var binding: ActivityMainBinding
 
+    @SuppressLint("RestrictedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -31,6 +29,7 @@ class MainActivity : AppCompatActivity() {
         val navController = findNavController(R.id.nav_host_fragment_content)
         appBarConfiguration = AppBarConfiguration(navController.graph)
         setupActionBarWithNavController(navController, appBarConfiguration)
+        navController.enableOnBackPressed(false)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -68,25 +67,8 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private val backPressedCallback = object : OnBackPressedCallback(true) {
-        override fun handleOnBackPressed() {
-            val navController = findNavController(R.id.nav_host_fragment_content)
-            val anonymousFragments = arrayOf(R.id.registration_fragment, R.id.login_fragment)
-
-            // Check if current and previous fragments are anonymous
-            if (anonymousFragments.contains(navController.currentDestination!!.id)) {
-                // Handle back press for anonymous fragments (e.g., display confirmation dialog)
-                // You can also use `super.onBackPressed()` here if needed
-            } else {
-                // Allow default back navigation for other fragments
-                navController.navigateUp()
-            }
-        }
-    }
-
     override fun onDestroy() {
         PreferenceManager.getDefaultSharedPreferences(applicationContext).edit().clear().commit()
-        backPressedCallback.remove()
         super.onDestroy()
     }
 }

--- a/app/src/main/java/dev/passwordless/sampleapp/auth/Session.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/auth/Session.kt
@@ -1,6 +1,8 @@
 package dev.passwordless.sampleapp.auth
 
 import android.content.Context
+import android.content.Context.MODE_MULTI_PROCESS
+import android.content.Context.MODE_PRIVATE
 import androidx.preference.PreferenceManager
 import com.auth0.android.jwt.JWT
 
@@ -17,8 +19,19 @@ data class Session(val context: Context) {
         return getJwt()?.getClaim("unique_name")?.asString() ?: null
     }
 
+    fun setJwtString(jwt: String) {
+        val sharedPreferences = context.getSharedPreferences("pwdemo", MODE_PRIVATE)
+        with(sharedPreferences.edit()) {
+            putString("jwt", jwt)
+            commit()
+        }
+    }
+
     fun getJwtString(): String? {
-        return PreferenceManager.getDefaultSharedPreferences(context).getString("jwt", null)
+        val sharedPreferences = context.getSharedPreferences("pwdemo", MODE_PRIVATE)
+        with(sharedPreferences) {
+            return getString("jwt", null)
+        }
     }
 
     private fun getJwt(): JWT? {

--- a/app/src/main/java/dev/passwordless/sampleapp/di/FragmentModule.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/di/FragmentModule.kt
@@ -5,31 +5,29 @@ import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.lifecycleScope
-import androidx.preference.PreferenceManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.components.FragmentComponent
 import dagger.hilt.android.qualifiers.ActivityContext
-import dagger.hilt.android.scopes.ActivityScoped
+import dagger.hilt.android.scopes.FragmentScoped
 import dev.passwordless.android.PasswordlessClient
 import dev.passwordless.android.rest.PasswordlessOptions
 import dev.passwordless.sampleapp.auth.Session
 import dev.passwordless.sampleapp.config.DemoPasswordlessOptions
 import dev.passwordless.sampleapp.yourbackend.YourBackendHttpClient
 import dev.passwordless.sampleapp.yourbackend.YourBackendHttpClientFactory
-import javax.inject.Singleton
 
 @Module
-@InstallIn(ActivityComponent::class)
-class ActivityModule {
+@InstallIn(FragmentComponent::class)
+class FragmentModule {
     @Provides
     fun provideLifecycleCoroutineScope(activity: Activity): LifecycleCoroutineScope =
         (activity as AppCompatActivity).lifecycleScope
 
 
     @Provides
-    @ActivityScoped
+    @FragmentScoped
     fun providePasswordlessClient(
         @ActivityContext activity: Context, scope: LifecycleCoroutineScope
     ): PasswordlessClient {
@@ -44,13 +42,13 @@ class ActivityModule {
     }
 
     @Provides
-    @ActivityScoped
+    @FragmentScoped
     fun provideRetrofitClient(session: Session): YourBackendHttpClient {
         return YourBackendHttpClientFactory.create(DemoPasswordlessOptions.YOUR_BACKEND_URL, session)
     }
 
     @Provides
-    @ActivityScoped
+    @FragmentScoped
     fun provideSession(@ActivityContext activity: Context): Session {
         return Session(activity!!.applicationContext)
     }


### PR DESCRIPTION
## 🎟️ Tracking

## 🚧 Type of change

- 🐛 Bug fix

## 📔 Objective

Logging in does not seem to successfully use the newly obtained JWT token.

## 📋 Code changes

- When navigating between fragments, the activity is not being destroyed and recreated, causing the `SharedPreferences` to possibly not read the newly written values.

## 📸 Screenshots

n/a

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
