### PR TITLE
Implement `Client-Version` header

### DIFF
--- a/passwordless/build.gradle.kts
+++ b/passwordless/build.gradle.kts
@@ -12,13 +12,23 @@ android {
     compileSdk = 34
 
     defaultConfig {
+        version = "1.0.2"
         minSdk = 28
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     buildTypes {
+        debug {
+            buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
+        }
+
         release {
+            buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -37,7 +47,7 @@ android {
     }
 
     mavenPublishing {
-        coordinates("com.bitwarden", "passwordless-android", "1.0.1")
+        coordinates("com.bitwarden", "passwordless-android", project.version.toString())
         // publishToMavenCentral(SonatypeHost.DEFAULT)
         publishToMavenCentral(SonatypeHost.S01)
         signAllPublications()

--- a/passwordless/src/main/java/dev/passwordless/android/rest/PasswordlessHttpClientFactory.kt
+++ b/passwordless/src/main/java/dev/passwordless/android/rest/PasswordlessHttpClientFactory.kt
@@ -2,6 +2,7 @@ package dev.passwordless.android.rest
 
 import com.google.gson.Gson
 import dev.passwordless.android.rest.interceptors.ApikeyHeaderInterceptor
+import dev.passwordless.android.rest.interceptors.ClientVersionHeaderInterceptor
 import dev.passwordless.android.rest.interceptors.ProblemDetailsInterceptor
 import dev.passwordless.android.rest.serializers.JsonSerializerImpl
 import okhttp3.OkHttpClient
@@ -15,6 +16,7 @@ object PasswordlessHttpClientFactory {
 
         val client = OkHttpClient.Builder()
             .addInterceptor(ApikeyHeaderInterceptor(options.apiKey))
+            .addInterceptor(ClientVersionHeaderInterceptor())
             .addInterceptor(ProblemDetailsInterceptor())
             .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
             .build()

--- a/passwordless/src/main/java/dev/passwordless/android/rest/interceptors/ClientVersionHeaderInterceptor.kt
+++ b/passwordless/src/main/java/dev/passwordless/android/rest/interceptors/ClientVersionHeaderInterceptor.kt
@@ -1,0 +1,18 @@
+package dev.passwordless.android.rest.interceptors
+
+
+import dev.passwordless.android.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class ClientVersionHeaderInterceptor() : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response = chain.run {
+        val versionName = BuildConfig.VERSION_NAME
+        proceed(
+            request()
+                .newBuilder()
+                .header("Client-Version", "android-$versionName")
+                .build()
+        )
+    }
+}


### PR DESCRIPTION
## 🚧 Type of change

- 🚀 New feature development

## 📔 Objective

We want to be able to track the version number of the library to be able to help customers better.

## 📋 Code changes

Intercept the requests to `Passwordless.dev` and add the `Client-Version` header.
