### PR TITLE
Add `INTERNET` permission through the library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,27 @@ Apache Maven
 <dependency>
   <groupId>com.bitwarden</groupId>
   <artifactId>passwordless-android</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 
 Gradle Kotlin DSL
 
 ```kotlin
-implementation("com.bitwarden:passwordless-android:1.0.1")
+implementation("com.bitwarden:passwordless-android:1.0.4")
 ```
 
 Gradle Groovy DSL
 
 ```groovy
-implementation 'com.bitwarden:passwordless-android:1.0.1'
+implementation 'com.bitwarden:passwordless-android:1.0.4'
 ```
 
 ### Permissions
 
-In your `AndroidManifest.xml`, you will need to add the following permissions:
+When the library has been added to your app, the following permission will be added automatically.
+
+It is not necessary for you to add the following permission.
 
 ```xml
 <uses-permission android:name="android.permission.INTERNET" />

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ implementation 'com.bitwarden:passwordless-android:1.0.4'
 
 ### Permissions
 
-When the library has been added to your app, the following permission will be added automatically.
+When the library has been added to your app, the following permission will be added to your `AndroidManifest.xml` automatically when the app is being built.
 
 It is not necessary for you to add the following permission.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-
     <application
         android:name="dev.passwordless.sampleapp.DemoApplication"
         android:allowBackup="true"

--- a/passwordless/build.gradle.kts
+++ b/passwordless/build.gradle.kts
@@ -12,7 +12,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        version = "1.0.3"
+        version = "1.0.4"
         minSdk = 28
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/passwordless/src/main/AndroidManifest.xml
+++ b/passwordless/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
### Description

The `INTERNET` permission should be added through the library when it is referenced in the app project.

This could potentially make the integration easier if more permissions are to be required in the future. 

### Shape

We can now remove the `INTERNET` permission theoretically in our app manifest, although our app also specifically requires  the `INTERNET` permission to communicate with the demo backend that we have hosted. This demo backend would be the customer's backend where the integration would happen.

### Screenshots

n/a

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
