### PR TITLE
RPID has changed.

### DIFF
--- a/app/src/main/java/dev/passwordless/sampleapp/config/DemoPasswordlessOptions.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/config/DemoPasswordlessOptions.kt
@@ -11,8 +11,8 @@ package dev.passwordless.sampleapp.config
 class DemoPasswordlessOptions {
     companion object {
         const val API_KEY = "pwdemo:public:5aec1f24f65343239bf4e1c9a852e871"
-        const val RP_ID = "demo.lesspassword.dev"
-        const val YOUR_BACKEND_URL = "https://demo.lesspassword.dev"
+        const val RP_ID = "demo.passwordless.dev"
+        const val YOUR_BACKEND_URL = "https://demo.passwordless.dev"
         const val ORIGIN = "android:apk-key-hash:oSQ_L7vpI6fdhEtKK6QKxy7A1o2GkJTK569M3toUIWU"
         const val API_URL = "https://v4.passwordless.dev"
     }

--- a/app/src/main/java/dev/passwordless/sampleapp/config/DemoPasswordlessOptions.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/config/DemoPasswordlessOptions.kt
@@ -11,8 +11,8 @@ package dev.passwordless.sampleapp.config
 class DemoPasswordlessOptions {
     companion object {
         const val API_KEY = "pwdemo:public:5aec1f24f65343239bf4e1c9a852e871"
-        const val RP_ID = "pwdemo.lesspassword.dev"
-        const val YOUR_BACKEND_URL = "https://pwdemo.lesspassword.dev"
+        const val RP_ID = "demo.lesspassword.dev"
+        const val YOUR_BACKEND_URL = "https://demo.lesspassword.dev"
         const val ORIGIN = "android:apk-key-hash:oSQ_L7vpI6fdhEtKK6QKxy7A1o2GkJTK569M3toUIWU"
         const val API_URL = "https://v4.passwordless.dev"
     }


### PR DESCRIPTION
### Description

The demo backend server has a new domain name `demo.lesspassword.dev` instead of `pwdemo.lesspassword.dev` that was initially created. This pull request aims to consolidate the changes to drop the `pwdemo.lesspassword.dev` domain.

### Shape

n/a

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
