### PR TITLE
BEEEP: Refactor navigation of unauthenticated and authenticated state.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="dev.passwordless.sampleapp.AuthorizedActivity"
+            android:exported="false"
+            android:label="@string/app_name">
+        </activity>
+
         <!-- Digital Asset Links -->
         <meta-data
             android:name="asset_statements"

--- a/app/src/main/java/dev/passwordless/sampleapp/AddCredentialFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/AddCredentialFragment.kt
@@ -1,5 +1,6 @@
 package dev.passwordless.sampleapp;
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -37,7 +38,9 @@ class AddCredentialFragment : Fragment() {
         _binding = FragmentAddCredentialBinding.inflate(inflater, container, false)
 
         if (!session.isLoggedIn()) {
-            findNavController().navigate(R.id.action_add_credential_to_login_fragment)
+            val intent = Intent(context, MainActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            requireContext().startActivity(intent)
         }
 
         return binding.root

--- a/app/src/main/java/dev/passwordless/sampleapp/AuthorizedActivity.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/AuthorizedActivity.kt
@@ -1,0 +1,56 @@
+package dev.passwordless.sampleapp
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.findNavController
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.setupActionBarWithNavController
+import androidx.preference.PreferenceManager
+import dagger.hilt.android.AndroidEntryPoint
+import dev.passwordless.sampleapp.databinding.ActivityAuthorizedBinding
+import dev.passwordless.sampleapp.databinding.ActivityMainBinding
+
+@AndroidEntryPoint
+class AuthorizedActivity : AppCompatActivity() {
+
+    private lateinit var appBarConfiguration: AppBarConfiguration
+    private lateinit var binding: ActivityAuthorizedBinding
+
+    @SuppressLint("RestrictedApi")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ActivityAuthorizedBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar)
+        val navController = findNavController(R.id.authorized_nav_host_fragment_content)
+        appBarConfiguration = AppBarConfiguration(navController.graph)
+        setupActionBarWithNavController(navController, appBarConfiguration)
+        navController.enableOnBackPressed(false)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        menuInflater.inflate(R.menu.menu_main, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        // Handle action bar item clicks here. The action bar will
+        // automatically handle clicks on the Home/Up button, so long
+        // as you specify a parent activity in AndroidManifest.xml.
+        return when (item.itemId) {
+            R.id.action_settings -> true
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onDestroy() {
+        PreferenceManager.getDefaultSharedPreferences(applicationContext).edit().clear().commit()
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/dev/passwordless/sampleapp/CredentialsFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/CredentialsFragment.kt
@@ -1,5 +1,6 @@
 package dev.passwordless.sampleapp
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -47,7 +48,9 @@ class CredentialsFragment : Fragment() {
         }
 
         if (!session.isLoggedIn()) {
-            findNavController().navigate(R.id.action_credentials_to_login_fragment)
+            val intent = Intent(context, MainActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+            requireContext().startActivity(intent)
         }
 
         return binding.root

--- a/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/LoginFragment.kt
@@ -1,6 +1,7 @@
 package dev.passwordless.sampleapp
 
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
@@ -84,7 +85,9 @@ class LoginFragment : Fragment() {
                                     ).show()
                                 } else {
                                     session.setJwtString(data.jwtToken)
-                                    findNavController().navigate(R.id.action_login_to_credentials_fragment)
+                                    val intent = Intent(context, AuthorizedActivity::class.java)
+                                    intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+                                    requireContext().startActivity(intent)
                                 }
                             }
                         }

--- a/app/src/main/res/layout/activity_authorized.xml
+++ b/app/src/main/res/layout/activity_authorized.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:context="dev.passwordless.sampleapp.AuthorizedActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:titleTextColor="@color/white" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <include layout="@layout/authorized_content" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/authorized_content.xml
+++ b/app/src/main/res/layout/authorized_content.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <fragment
+        android:id="@+id/authorized_nav_host_fragment_content"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/authorized_nav_graph" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/authorized_nav_graph.xml
+++ b/app/src/main/res/navigation/authorized_nav_graph.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/authorized_nav_graph"
+    app:startDestination="@id/credentials_fragment">
+
+    <fragment
+        android:id="@+id/credentials_fragment"
+        android:name="dev.passwordless.sampleapp.CredentialsFragment"
+        android:label="@string/credentials_fragment_label"
+        tools:layout="@layout/fragment_credentials">
+
+        <action
+            android:id="@+id/action_credentials_to_add_credential_fragment"
+            app:destination="@id/add_credential_fragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/add_credential_fragment"
+        android:name="dev.passwordless.sampleapp.AddCredentialFragment"
+        android:label="@string/add_credential_fragment_label"
+        tools:layout="@layout/fragment_add_credential">
+
+        <action
+            android:id="@+id/action_add_credential_to_credentials_fragment"
+            app:destination="@id/credentials_fragment" />
+    </fragment>
+</navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -25,35 +25,5 @@
             android:id="@+id/action_login_to_registration_fragment"
             app:destination="@id/registration_fragment" />
 
-        <action
-            android:id="@+id/action_login_to_credentials_fragment"
-            app:destination="@id/credentials_fragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/credentials_fragment"
-        android:name="dev.passwordless.sampleapp.CredentialsFragment"
-        android:label="@string/credentials_fragment_label"
-        tools:layout="@layout/fragment_credentials">
-
-        <action
-            android:id="@+id/action_credentials_to_login_fragment"
-            app:destination="@id/login_fragment" />
-
-        <action
-            android:id="@+id/action_credentials_to_add_credential_fragment"
-            app:destination="@id/add_credential_fragment" />
-    </fragment>
-    <fragment
-        android:id="@+id/add_credential_fragment"
-        android:name="dev.passwordless.sampleapp.AddCredentialFragment"
-        android:label="@string/add_credential_fragment_label"
-        tools:layout="@layout/fragment_add_credential">
-
-        <action
-            android:id="@+id/action_add_credential_to_credentials_fragment"
-            app:destination="@id/credentials_fragment" />
-        <action
-            android:id="@+id/action_add_credential_to_login_fragment"
-            app:destination="@id/login_fragment" />
     </fragment>
 </navigation>


### PR DESCRIPTION
### Description

Refactors the navigation between authenticated and unauthenticated state. Previously what was happening was that after logging in you're redirected to the CredentialsFragment, but when you press the back button, you're navigating back to the login screen, however, you're actually logged in, so you shouldn't be seeing this activity. Instead what we want is to close the app for convenience to avoid confusion.

Unauthenticated and authenticated sessions have therefore now their own navigation graphs. And it doesn't involve any ugly hacks that require to clear the navigation history stack.

### Shape

n/a

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
