### PR TITLE
Use `FirstName` & `LastName` fields for registration.

### DIFF
--- a/app/src/main/java/dev/passwordless/sampleapp/AddCredentialFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/AddCredentialFragment.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.passwordless.android.PasswordlessClient
 import dev.passwordless.android.utils.PasswordlessUtils
 import dev.passwordless.sampleapp.auth.Session
+import dev.passwordless.sampleapp.contracts.AddCredentialRequest
 import dev.passwordless.sampleapp.contracts.UserRegisterRequest
 import dev.passwordless.sampleapp.databinding.FragmentAddCredentialBinding
 import dev.passwordless.sampleapp.yourbackend.YourBackendHttpClient
@@ -54,8 +55,7 @@ class AddCredentialFragment : Fragment() {
                 val alias = binding.aliasEditText.text.toString()
                 val username = session.getUsername()!!
                 try {
-                    val response =
-                        httpClient.register(UserRegisterRequest(username, alias)).body()?.token!!
+                    val response = httpClient.addCredential(session.getUserId()!!, AddCredentialRequest(alias)).body()?.token!!
                     passwordless.register(
                         response,
                         alias + username

--- a/app/src/main/java/dev/passwordless/sampleapp/RegisterFragment.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/RegisterFragment.kt
@@ -56,13 +56,14 @@ class RegisterFragment : Fragment() {
             lifecycleScope.launch {
                 val alias = binding.aliasEditText.text.toString()
                 val username = binding.usernameEditText.text.toString()
+                val firstName = binding.firstNameEditText.text.toString()
+                val lastName = binding.lastNameEditText.text.toString()
                 try {
-                    val responseToken =
-                        httpClient.register(UserRegisterRequest(username, alias)).body()?.token!!
+                    val registerRequest = UserRegisterRequest(username, alias, firstName, lastName)
+                    val responseToken = httpClient.register(registerRequest).body()?.token!!
                     _passwordless.register(
                         responseToken,
-                        alias + username
-                    ) { success, exception, result ->
+                        alias + username) { success, exception, result ->
                         if (success) {
                             Toast.makeText(context, result.toString(), Toast.LENGTH_SHORT).show()
                         } else {

--- a/app/src/main/java/dev/passwordless/sampleapp/contracts/AddCredentialResponse.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/contracts/AddCredentialResponse.kt
@@ -1,0 +1,3 @@
+package dev.passwordless.sampleapp.contracts
+
+data class AddCredentialResponse(val token: String)

--- a/app/src/main/java/dev/passwordless/sampleapp/contracts/UserRegisterRequest.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/contracts/UserRegisterRequest.kt
@@ -2,5 +2,7 @@ package dev.passwordless.sampleapp.contracts
 
 data class UserRegisterRequest(
     val username:String,
-    val alias: String
+    val alias: String,
+    val firstName: String,
+    val lastName: String
 )

--- a/app/src/main/java/dev/passwordless/sampleapp/yourbackend/YourBackendHttpClient.kt
+++ b/app/src/main/java/dev/passwordless/sampleapp/yourbackend/YourBackendHttpClient.kt
@@ -1,5 +1,7 @@
 package dev.passwordless.sampleapp.yourbackend
 
+import dev.passwordless.sampleapp.contracts.AddCredentialRequest
+import dev.passwordless.sampleapp.contracts.AddCredentialResponse
 import dev.passwordless.sampleapp.contracts.CredentialResponse
 import dev.passwordless.sampleapp.contracts.RegisterTokenResponse
 import dev.passwordless.sampleapp.contracts.UserLoginRequest
@@ -17,4 +19,7 @@ interface YourBackendHttpClient {
 
     @GET("/users/{userId}/credentials")
     suspend fun getCredentials(@Path("userId") userId: String): Response<List<CredentialResponse>>
+
+    @POST("/users/{userId}/credentials")
+    suspend fun addCredential(@Path("userId") userId: String, @Body request: AddCredentialRequest): Response<AddCredentialResponse>
 }

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -17,13 +17,36 @@
 
         <EditText
             android:id="@+id/usernameEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:ems="10"
+            android:gravity="center"
+            android:hint="@string/username_hint"
+            android:inputType="text"
+            android:maxLength="20" />
+
+        <EditText
+            android:id="@+id/firstNameEditText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:ems="10"
+            android:gravity="center"
+            android:hint="@string/firstname_hint"
+            android:inputType="text"
+            android:maxLength="30" />
+
+        <EditText
+            android:id="@+id/lastNameEditText"
             android:gravity="center"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:ems="10"
-            android:hint="@string/username_hint"
-            android:inputType="text" />
+            android:hint="@string/lastname_hint"
+            android:inputType="text"
+            android:maxLength="30" />
 
         <LinearLayout
             android:gravity="center"
@@ -38,7 +61,8 @@
                 android:layout_height="wrap_content"
                 android:ems="10"
                 android:hint="@string/alias_hint"
-                android:inputType="text" />
+                android:inputType="text"
+                android:maxLength="20" />
 
             <TextView
                 android:gravity="center"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
     <string name="app_name">Passwordless.dev Android Sample</string>
     <string name="action_settings">Settings</string>
 
-    <!-- Strings used for fragments for navigation -->
     <string name="register_fragment_label">Registration</string>
     <string name="login_fragment_label">Login</string>
     <string name="credentials_fragment_label">Credentials</string>
@@ -12,6 +11,8 @@
     <string name="previous">Previous</string>
 
     <string name="username_hint">Username</string>
+    <string name="firstname_hint">First Name</string>
+    <string name="lastname_hint">Last Name</string>
     <string name="alias">Alias</string>
     <string name="alias_hint">Alias (optional)</string>
     <string name="alias_hint_description">When \'alias\' is left empty, your credential will be discoverable. You won\'t have to enter the \'alias\' value entered previously to log in.</string>


### PR DESCRIPTION
### Description

- Implements the `First Name` & `Last Name` fields added to the `Users` table.
- Upon extending the functionality, I discovered I implemented adding additional credentials incorrectly using the registration endpoint. We now properly use the `POST /users/{userId}/credentials` endpoint to add additional passkeys.

### Shape
<!--
    Give a high-level overview of the technical design involved in the implemented changes.
    If the changes don't have any architectural impact, you can remove this section.
-->

### Screenshots
<!--
    Include any relevant UI screenshots showcasing the before & after of your changes.
    If the changes don't have any UI impact, you can remove this section.
-->

### Checklist
I did the following to ensure that my changes were tested thoroughly:
- __

I did the following to ensure that my changes do not introduce security vulnerabilities:
- __
