### PR TITLE
[BRE-831] migrate secrets AKV

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -44,7 +44,7 @@ jobs:
       uses: bitwarden/gh-actions/get-keyvault-secrets@main
       with:
         keyvault: "gh-passwordless-android"
-        secrets: "OSSRH_USERNAME,OSSRH_TOKEN,GPG_KEY,GPG_PASSPHRASE"
+        secrets: "OSSRH-USERNAME,OSSRH-TOKEN,GPG-KEY,GPG-PASSPHRASE"
 
     - name: Azure Logout
       uses: bitwarden/gh-actions/azure-logout@main
@@ -54,8 +54,8 @@ jobs:
 
     - name: Build with Gradle
       env:
-        _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ steps.get-kv-secrets.outputs.OSSRH_USERNAME }}
-        _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ steps.get-kv-secrets.outputs.OSSRH_TOKEN }}
-        _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ steps.get-kv-secrets.outputs.GPG_KEY }}
-        _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ steps.get-kv-secrets.outputs.GPG_PASSPHRASE }}
+        _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ steps.get-kv-secrets.outputs.OSSRH-USERNAME }}
+        _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ steps.get-kv-secrets.outputs.OSSRH-TOKEN }}
+        _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ steps.get-kv-secrets.outputs.GPG-KEY }}
+        _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ steps.get-kv-secrets.outputs.GPG-PASSPHRASE }}
       run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,6 @@ jobs:
       run: chmod +x gradlew
 
     - name: Log in to Azure
-      id: azure-login
       uses: bitwarden/gh-actions/azure-login@main
       with:
         subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,13 +9,10 @@ on:
 jobs:
   build:
     name: Build
-    env:
-      _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-      _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
-      _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
-      _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
-
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - name: Check out repo
@@ -34,8 +31,31 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: Azure Login
+      id: azure-login
+      uses: bitwarden/gh-actions/azure-login@main
+      with:
+        subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+        client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+    - name: Get KV secrets
+      id: get-kv-secrets
+      uses: bitwarden/gh-actions/get-keyvault-secrets@main
+      with:
+        keyvault: "gh-passwordless-android"
+        secrets: "OSSRH_USERNAME,OSSRH_TOKEN,GPG_KEY,GPG_PASSPHRASE"
+
+    - name: Azure Logout
+      uses: bitwarden/gh-actions/azure-logout@main
+
     - name: Lint
       run: ./gradlew check
 
     - name: Build with Gradle
+      env:
+        _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ steps.get-kv-secrets.outputs.OSSRH_USERNAME }}
+        _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ steps.get-kv-secrets.outputs.OSSRH_TOKEN }}
+        _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ steps.get-kv-secrets.outputs.GPG_KEY }}
+        _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ steps.get-kv-secrets.outputs.GPG_PASSPHRASE }}
       run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,7 +39,7 @@ jobs:
         tenant_id: ${{ secrets.AZURE_TENANT_ID }}
         client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-    - name: Get Azure Key Vault Secrets
+    - name: Get Azure Key Vault secrets
       id: get-kv-secrets
       uses: bitwarden/gh-actions/get-keyvault-secrets@main
       with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Azure Login
+    - name: Log in to Azure
       id: azure-login
       uses: bitwarden/gh-actions/azure-login@main
       with:
@@ -39,14 +39,14 @@ jobs:
         tenant_id: ${{ secrets.AZURE_TENANT_ID }}
         client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-    - name: Get KV secrets
+    - name: Get Azure Key Vault Secrets
       id: get-kv-secrets
       uses: bitwarden/gh-actions/get-keyvault-secrets@main
       with:
         keyvault: "gh-passwordless-android"
         secrets: "OSSRH-USERNAME,OSSRH-TOKEN,GPG-KEY,GPG-PASSPHRASE"
 
-    - name: Azure Logout
+    - name: Log out from Azure
       uses: bitwarden/gh-actions/azure-logout@main
 
     - name: Lint

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,6 +50,11 @@ jobs:
       uses: bitwarden/gh-actions/azure-logout@main
 
     - name: Lint
+      env:
+        _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ steps.get-kv-secrets.outputs.OSSRH-USERNAME }}
+        _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ steps.get-kv-secrets.outputs.OSSRH-TOKEN }}
+        _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ steps.get-kv-secrets.outputs.GPG-KEY }}
+        _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ steps.get-kv-secrets.outputs.GPG-PASSPHRASE }}
       run: ./gradlew check
 
     - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault Secrets
+      - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout step
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -25,10 +28,28 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get KV secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: "gh-passwordless-android"
+          secrets: "OSSRH_USERNAME,OSSRH_TOKEN,GPG_KEY,GPG_PASSPHRASE"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
+
       - name: Gradle Publish
         env:
-          _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
-          _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
-          _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
+          _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ steps.get-kv-secrets.outputs.OSSRH_USERNAME }}
+          _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ steps.get-kv-secrets.outputs.OSSRH_TOKEN }}
+          _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ steps.get-kv-secrets.outputs.GPG_KEY }}
+          _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ steps.get-kv-secrets.outputs.GPG_PASSPHRASE }}
         run: ./gradlew publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -36,14 +36,14 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get KV secrets
+      - name: Get Azure Key Vault Secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: "gh-passwordless-android"
           secrets: "OSSRH-USERNAME,OSSRH-TOKEN,GPG-KEY,GPG-PASSPHRASE"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Gradle Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,15 +41,15 @@ jobs:
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: "gh-passwordless-android"
-          secrets: "OSSRH_USERNAME,OSSRH_TOKEN,GPG_KEY,GPG_PASSPHRASE"
+          secrets: "OSSRH-USERNAME,OSSRH-TOKEN,GPG-KEY,GPG-PASSPHRASE"
 
       - name: Azure Logout
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Gradle Publish
         env:
-          _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ steps.get-kv-secrets.outputs.OSSRH_USERNAME }}
-          _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ steps.get-kv-secrets.outputs.OSSRH_TOKEN }}
-          _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ steps.get-kv-secrets.outputs.GPG_KEY }}
-          _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ steps.get-kv-secrets.outputs.GPG_PASSPHRASE }}
+          _ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ steps.get-kv-secrets.outputs.OSSRH-USERNAME }}
+          _ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ steps.get-kv-secrets.outputs.OSSRH-TOKEN }}
+          _ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ steps.get-kv-secrets.outputs.GPG-KEY }}
+          _ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ steps.get-kv-secrets.outputs.GPG-PASSPHRASE }}
         run: ./gradlew publish

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           ref: ${{  github.event.pull_request.head.sha }}
 
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -49,14 +49,14 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get KV secrets
+      - name: Get Azure Key Vault Secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
           secrets: "CHECKMARX-TENANT,CHECKMARX-CLIENT-ID,CHECKMARX-SECRET"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Scan with Checkmarx
@@ -97,7 +97,7 @@ jobs:
           fetch-depth: 0
           ref: ${{  github.event.pull_request.head.sha }}
 
-      - name: Azure Login
+      - name: Log in to Azure
         id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -105,14 +105,14 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get KV secrets
+      - name: Get Azure Key Vault Secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
           secrets: "SONAR-TOKEN"
 
-      - name: Azure Logout
+      - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
 
       - name: Scan with SonarCloud

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -42,7 +42,6 @@ jobs:
           ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -98,7 +97,6 @@ jobs:
           ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Log in to Azure
-        id: azure-login
         uses: bitwarden/gh-actions/azure-login@main
         with:
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,6 +20,8 @@ jobs:
   check-run:
     name: Check PR run
     uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+    permissions:
+      contents: read
 
   sast:
     name: SAST scan
@@ -29,6 +31,7 @@ jobs:
       contents: read
       pull-requests: write
       security-events: write
+      id-token: write
 
     steps:
       - name: Check out repo
@@ -36,16 +39,34 @@ jobs:
         with:
           ref: ${{  github.event.pull_request.head.sha }}
 
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get KV secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "CHECKMARX-TENANT,CHECKMARX-CLIENT-ID,CHECKMARX-SECRET"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
+
       - name: Scan with Checkmarx
         uses: checkmarx/ast-github-action@629a9fac14369bf2898d583b22bf8c40a5caf8e9 # 2.0.40
         env:
           INCREMENTAL: "${{ contains(github.event_name, 'pull_request') && '--sast-incremental' || '' }}"
         with:
           project_name: ${{ github.repository }}
-          cx_tenant: ${{ secrets.CHECKMARX_TENANT }}
+          cx_tenant: ${{ steps.get-kv-secrets.outputs.CHECKMARX-TENANT }}
           base_uri: https://ast.checkmarx.net/
-          cx_client_id: ${{ secrets.CHECKMARX_CLIENT_ID }}
-          cx_client_secret: ${{ secrets.CHECKMARX_SECRET }}
+          cx_client_id: ${{ steps.get-kv-secrets.outputs.CHECKMARX-CLIENT-ID }}
+          cx_client_secret: ${{ steps.get-kv-secrets.outputs.CHECKMARX-SECRET }}
           additional_params: |
             --report-format sarif \
             --filter "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT" \
@@ -65,6 +86,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Check out repo
@@ -73,10 +95,28 @@ jobs:
           fetch-depth: 0
           ref: ${{  github.event.pull_request.head.sha }}
 
+      - name: Azure Login
+        id: azure-login
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Get KV secrets
+        id: get-kv-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-org-bitwarden
+          secrets: "SONAR-TOKEN"
+
+      - name: Azure Logout
+        uses: bitwarden/gh-actions/azure-logout@main
+
       - name: Scan with SonarCloud
         uses: sonarsource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ steps.get-kv-secrets.outputs.SONAR-TOKEN }}
         with:
           args: >
             -Dsonar.organization=${{ github.repository_owner }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -49,7 +49,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault Secrets
+      - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
@@ -105,7 +105,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           client_id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get Azure Key Vault Secrets
+      - name: Get Azure Key Vault secrets
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-831](https://bitwarden.atlassian.net/browse/BRE-831)

## 📔 Objective

Updating to use Azure Key Vault Secrets in place of GitHub secrets.
All GitHub secrets have been migrated to the repository's respective Key Vault.
Azure Service Principals have been updated to use Managed Identities with OIDC.

[BRE-831]: https://bitwarden.atlassian.net/browse/BRE-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ